### PR TITLE
Updated RestRequest to use http client factory rather than http client directly

### DIFF
--- a/src/RestLess.Core/RestRequest/RestRequest.Send.cs
+++ b/src/RestLess.Core/RestRequest/RestRequest.Send.cs
@@ -13,7 +13,7 @@ namespace RestLess.Internal
         public Task<HttpResponseMessage> ReadAsHttpResponseMessageAsync(CancellationToken cancellationToken = default)
         {
             this.EnsureAllIsSetBeforeSendingTheRequest();
-            return this.restClient.HttpClient.SendAsync(this.httpRequestMessage, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return this.restClient.HttpClientFactory().SendAsync(this.httpRequestMessage, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         public Task<string> ReadAsStringAsync(CancellationToken cancellationToken = default)
@@ -70,7 +70,7 @@ namespace RestLess.Internal
         private Task<HttpResponseMessage> ReadAsHttpResponseMessageWithoutContent(CancellationToken cancellationToken = default)
         {
             this.EnsureAllIsSetBeforeSendingTheRequest();
-            return this.restClient.HttpClient.SendAsync(this.httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            return this.restClient.HttpClientFactory().SendAsync(this.httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
         }
 
         private async Task<T> ReadHttpContentAsync<T>(Func<HttpContent, Task<T>> func, CancellationToken cancellationToken = default)

--- a/src/RestLess.Shared/Interfaces/IRestClient.cs
+++ b/src/RestLess.Shared/Interfaces/IRestClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace RestLess
 {
@@ -8,9 +9,9 @@ namespace RestLess
     public interface IRestClient
     {
         /// <summary>
-        /// Gets or sets the http client.
+        /// Gets or sets the http client factory.
         /// </summary>
-        HttpClient HttpClient { get; set; }
+        Func<HttpClient> HttpClientFactory { get; set; }
 
         /// <summary>
         /// Gets or sets the REST settings.

--- a/src/RestLess.Shared/RestClientBase.cs
+++ b/src/RestLess.Shared/RestClientBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace RestLess.Generated
 {
@@ -12,7 +13,7 @@ namespace RestLess.Generated
         /// </summary>
         protected RestClientBase() { }
 
-        HttpClient IRestClient.HttpClient { get; set; }
+        Func<HttpClient> IRestClient.HttpClientFactory { get; set; }
 
         RestSettings IRestClient.Settings { get; set; }
     }

--- a/src/RestLess.Shared/RestClientFactory.cs
+++ b/src/RestLess.Shared/RestClientFactory.cs
@@ -31,6 +31,30 @@ namespace RestLess.Generated
             this.initializers[typeof(TInterface)] = () => new TImplementation();
         }
 
+
+        /// <summary>
+        /// Creates a REST client from a httpClientFactory.
+        /// </summary>
+        /// <typeparam name="T">The type of the REST client.</typeparam>
+        /// <param name="httpClient">The httpClientFactory.</param>
+        /// <param name="settings">The REST settings.</param>
+        /// <returns></returns>
+        public T Create<T>(Func<HttpClient> httpClientFactory, RestSettings settings)
+            where T : class
+        {
+            settings = settings ?? new RestSettings();
+            if (!this.initializers.TryGetValue(typeof(T), out Func<IRestClient> initializer))
+            {
+                throw new ArgumentException($"The type '{typeof(T).FullName}' is not a Rest interface.");
+            }
+
+            IRestClient restClient = initializer();
+            restClient.HttpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+            restClient.Settings = settings;
+            return (T)restClient;
+        }
+
+
         /// <summary>
         /// Creates a REST client from a <see cref="HttpClient"/>.
         /// </summary>
@@ -41,16 +65,7 @@ namespace RestLess.Generated
         public T Create<T>(HttpClient httpClient, RestSettings settings)
             where T : class
         {
-            settings = settings ?? new RestSettings();
-            if (!this.initializers.TryGetValue(typeof(T), out Func<IRestClient> initializer))
-            {
-                throw new ArgumentException($"The type '{typeof(T).FullName}' is not a Rest interface.");
-            }
-
-            IRestClient restClient = initializer();
-            restClient.HttpClient = httpClient;
-            restClient.Settings = settings;
-            return (T)restClient;
+            return this.Create<T>(() => httpClient, settings);
         }
 
         /// <summary>

--- a/src/RestLess.Tasks/RestClient.cs
+++ b/src/RestLess.Tasks/RestClient.cs
@@ -12,6 +12,19 @@ namespace RestLess
         private static readonly RestClientFactory RestClientFactory = null;
 
         /// <summary>
+        /// Creates a Rest client using the specified <paramref name="httpClientFactory"/> and <paramref name="settings"/>.
+        /// </summary>
+        /// <typeparam name="T">The interface of the Rest client.</typeparam>
+        /// <param name="httpClientFactory">The http client factory.</param>
+        /// <param name="settings">The optional settings.</param>
+        /// <returns></returns>
+        public static T For<T>(Func<HttpClient> httpClientFactory, RestSettings settings = null)
+            where T : class
+        {
+            return RestClientFactory.Create<T>(httpClientFactory, settings);
+        }
+
+        /// <summary>
         /// Creates a Rest client using the specified <paramref name="httpClient"/> and <paramref name="settings"/>.
         /// </summary>
         /// <typeparam name="T">The interface of the Rest client.</typeparam>


### PR DESCRIPTION
Currently the RestClients generated hold onto the http client for the lifecycle of the client. This change would allow the user to pass in something else that manages the lifecycle of the http client

e.g. IHttpClientFactory https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-2.2.

https://github.com/letsar/RestLess/issues/2